### PR TITLE
trying to make RAGGraphBuilder faster

### DIFF
--- a/histocartography/preprocessing/feature_extraction.py
+++ b/histocartography/preprocessing/feature_extraction.py
@@ -802,6 +802,7 @@ class DeepFeatureExtractor(FeatureExtractor):
             shuffle=False,
             batch_size=self.batch_size,
             num_workers=self.num_workers,
+            # num_workers=0,
             collate_fn=self._collate_patches
         )
         features = torch.empty(
@@ -816,6 +817,7 @@ class DeepFeatureExtractor(FeatureExtractor):
         for instance_indices, patches in tqdm(
             image_loader, total=len(image_loader), disable=not self.verbose
         ):
+        # for instance_indices, patches in enumerate(image_loader):
             emb = self.patch_feature_extractor(patches)
             for j, key in enumerate(instance_indices):
                 if key in embeddings:


### PR DESCRIPTION
Hello,

Thank you again for this package and all your work on it.

I was dabbling with the RAGGraphBuilder for my dataset and I wanted to try and make the tissue graph processing faster. 

I tried implementing multiprocessing on _set_node_labels and _build_topology with the pathos.multiprocessing ProcessPool. It works fine on my machine (maybe a 2-4x speedup), but it is far from an elegant solution.

I am sure there is a cleaner way to write this, maybe with joblib?
https://joblib.readthedocs.io/en/latest/parallel.html

One problem is that the memory consumption can spike fairly high above 50GB depending on the data and num_workers, so that might crash a job if someone isn't expecting it... Not sure what the work around is in Python, maybe using numba or something similar?

Anyways, thought I would pass it along. Thanks again!

Best,
Jack